### PR TITLE
feat(acms-rev-87): Delete review by reviewId

### DIFF
--- a/acms-react-app/src/App.js
+++ b/acms-react-app/src/App.js
@@ -130,6 +130,14 @@ const router = createBrowserRouter([
       {
         path: "/user",
         element: <User/>
+      },
+      {
+        path: "/user/reviews",
+        element: <Reviews/>
+      },
+      {
+        path: "/user/reviews/:reviewId",
+        element: <ReviewDetails/>
       }
 
     ]

--- a/acms-react-app/src/Pages/Admin_Pages/Reviews/Reviews_Page/ReviewDetails.js
+++ b/acms-react-app/src/Pages/Admin_Pages/Reviews/Reviews_Page/ReviewDetails.js
@@ -39,6 +39,20 @@ function ReviewDetails() {
             });
     }, [reviewId]);
 
+    function deleteReview() {
+        adminService.deleteReview(reviewId)
+            .then(res => {
+                if (res.status === 204) {
+                    alert('Review has been deleted!');
+                }
+            })
+            .catch(err => {
+                alert('You can only delete your own reviews.');
+            });
+        setShowConfirmation(false);
+    }
+    
+
     function updateReview(event) {
         event.preventDefault();
 
@@ -63,17 +77,6 @@ function ReviewDetails() {
         }));
     }
 
-    /*
-    function handleInputChange(event) {
-        const { name, value } = event.target;
-        setInvoiceDetails(prevState => ({
-            ...prevState,
-            [name]: value
-        }));
-    }
-
-
-
 
     function confirmDelete() {
         setShowConfirmation(true);
@@ -82,22 +85,7 @@ function ReviewDetails() {
     function cancelDelete() {
         setShowConfirmation(false);
     }
-
-    function deleteInvoice() {
-        adminService.deleteInvoice(invoiceId)
-            .then(res => {
-                if (res.status === 204) {
-                    alert('Invoice has been deleted!');
-                    navigate(`/admin/invoices`);
-                }
-            })
-            .catch(err => {
-                console.error('Error deleting invoice:', err);
-            });
-        setShowConfirmation(false);
-    }
-    */
-
+ 
     // Render the review details form
     return (
         <div className="flex flex-col min-h-screen">
@@ -131,17 +119,22 @@ function ReviewDetails() {
                       
                         <label className="font-bold">Reply</label>
                         <input className="w-full p-4 rounded border border-gray-400 mb-5" name="reviewId" value={reviewDetails.mechanicReply} type="text" placeholder="No reply"/>
+                        <div className="flex justify-center space-x-10">
                         <button className="bg-yellow-400 border-none px-4 py-2 rounded font-bold transform transition duration-300 hover:scale-110" type="submit">
                             Save
                         </button>
+                        <button className="bg-red-500 border-none px-4 py-2 rounded font-bold transform transition duration-300 hover:scale-110" onClick={confirmDelete} type="button">
+                        Delete
+                        </button>
+                        </div>
                     </form>
                         </div>
-                        {/*showConfirmation && (
+                        {showConfirmation && (
                                 <div className="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 flex justify-center items-center z-50">
                                     <div className="bg-white p-5 rounded-lg shadow-lg">
-                                        <p className="text-lg mb-2">Are you sure you want to delete this invoice?</p>
+                                        <p className="text-lg mb-2">Are you sure you want to delete this review?</p>
                                         <div className="flex justify-center space-x-4">
-                                            <button className="bg-red-500 text-white px-4 py-2 rounded font-bold" onClick={deleteInvoice}>
+                                            <button className="bg-red-500 text-white px-4 py-2 rounded font-bold" onClick={deleteReview}>
                                                 Yes
                                             </button>
                                             <button className="bg-gray-300 text-gray-700 px-4 py-2 rounded font-bold" onClick={cancelDelete}>
@@ -150,7 +143,7 @@ function ReviewDetails() {
                                         </div>
                                     </div>
                                 </div>
-                        )*/}
+                        )}
                         </main>
                     </div>
                 </div>

--- a/acms-react-app/src/Services/admin.service.js
+++ b/acms-react-app/src/Services/admin.service.js
@@ -118,6 +118,9 @@ class adminService{
     updateReview(id, review){
         return axios.put(API_REVIEWS_URL + `/${id}`, review, { headers: authHeader() });
     }
+    deleteReview(id){
+        return axios.delete(API_REVIEWS_URL + `/${id}`, { headers: authHeader() });
+    }
 
 }
 

--- a/acms-react-app/src/Services/customer.service.js
+++ b/acms-react-app/src/Services/customer.service.js
@@ -15,6 +15,22 @@ class customerService {
         return axios.get(`${API_AVAILABILITY_URL}${date}`, { headers: authHeader() });
     }
 
+    // reviews (good practice but maybe redundant in this case?)
+
+    /*
+    getAllReviews(){
+        return axios.get(API_REVIEWS_URL, { headers: authHeader() });
+    }
+
+    getReviewById(id){
+        return axios.get(API_REVIEWS_URL + /${id}, { headers: authHeader() });
+    }
+    deleteReviewById(id){
+        return axios.delete(API_REVIEWS_URL + /${id}, { headers: authHeader() });
+
+    }
+    */
+
 }
 
 export default new customerService();

--- a/ateliermecanique-ws/src/main/java/com/champlain/ateliermecaniquews/reviewssubdomain/businesslayer/ReviewService.java
+++ b/ateliermecanique-ws/src/main/java/com/champlain/ateliermecaniquews/reviewssubdomain/businesslayer/ReviewService.java
@@ -9,9 +9,8 @@ public interface ReviewService {
 
     List<ReviewResponseModel> getAllReviews();
     ReviewResponseModel getReviewByReviewId(String reviewId);
-
-
-
-
     ReviewResponseModel updateReview(String reviewId, ReviewRequestModel reviewResponseModel);
+
+    void deleteReviewByReviewId(String reviewId);
+    boolean isOwnerOfReview(String authenticatedUserId, String reviewId);
 }

--- a/ateliermecanique-ws/src/main/java/com/champlain/ateliermecaniquews/reviewssubdomain/businesslayer/ReviewServiceImpl.java
+++ b/ateliermecanique-ws/src/main/java/com/champlain/ateliermecaniquews/reviewssubdomain/businesslayer/ReviewServiceImpl.java
@@ -36,11 +36,6 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
 
-
-
-
-
-
     @Override
     public ReviewResponseModel updateReview(String reviewId, ReviewRequestModel reviewResponseModel) {
         Review review = reviewRepository.findReviewByReviewIdentifier_ReviewId(reviewId);
@@ -56,4 +51,18 @@ public class ReviewServiceImpl implements ReviewService {
         review.setReviewDate(reviewResponseModel.getReviewDate());
         return reviewResponseMapper.entityToResponseModel(reviewRepository.save(review));
     }
+
+    @Override
+    public void deleteReviewByReviewId(String reviewId) {
+        Review review = reviewRepository.findReviewByReviewIdentifier_ReviewId(reviewId);
+        if(review != null){
+            reviewRepository.delete(review);
+        }
+    }
+
+    @Override
+    public boolean isOwnerOfReview(String authenticatedUserId, String reviewId) {
+        return reviewRepository.findReviewByReviewIdentifier_ReviewIdAndCustomerId(reviewId, authenticatedUserId).isPresent();
+    }
+
 }

--- a/ateliermecanique-ws/src/main/java/com/champlain/ateliermecaniquews/reviewssubdomain/datalayer/ReviewRepository.java
+++ b/ateliermecanique-ws/src/main/java/com/champlain/ateliermecaniquews/reviewssubdomain/datalayer/ReviewRepository.java
@@ -2,7 +2,11 @@ package com.champlain.ateliermecaniquews.reviewssubdomain.datalayer;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReviewRepository extends JpaRepository<Review, Integer> {
 
     Review findReviewByReviewIdentifier_ReviewId(String reviewId);
+    Optional<Review> findReviewByReviewIdentifier_ReviewIdAndCustomerId(String reviewId, String customerId);
+
 }

--- a/ateliermecanique-ws/src/test/java/com/champlain/ateliermecaniquews/reviewssubdomain/businesslayer/ReviewServiceImplTest.java
+++ b/ateliermecanique-ws/src/test/java/com/champlain/ateliermecaniquews/reviewssubdomain/businesslayer/ReviewServiceImplTest.java
@@ -164,4 +164,63 @@ class ReviewServiceImplTest {
         assertEquals(rating, review.getRating());
 
     }
+
+    @Test
+    void updateReview_reviewNotFound_shouldLogWarningAndReturnNull() {
+        // Arrange
+        String nonExistentReviewId = "nonExistentReviewId";
+        ReviewRequestModel requestModel = new ReviewRequestModel(
+                "customerId",
+                "appointmentId",
+                "This is a comment",
+                5.0,
+                LocalDateTime.now()
+        );
+
+        when(reviewRepository.findReviewByReviewIdentifier_ReviewId(nonExistentReviewId)).thenReturn(null);
+
+        // Act
+        ReviewResponseModel result = reviewService.updateReview(nonExistentReviewId, requestModel);
+
+        // Assert
+        assertNull(result);
+        verify(reviewRepository, times(1)).findReviewByReviewIdentifier_ReviewId(nonExistentReviewId);
+        verify(reviewRepository, never()).save(any(Review.class));
+    }
+
+    @Test
+    void deleteReviewByReviewId_shouldSucceed() {
+        // Arrange
+        String reviewId = "existingReviewId";
+
+        // Mock the review to be deleted
+        Review reviewToDelete = new Review();
+        when(reviewRepository.findReviewByReviewIdentifier_ReviewId(reviewId))
+                .thenReturn(reviewToDelete);
+
+        // Act
+        reviewService.deleteReviewByReviewId(reviewId);
+
+        // Assert
+        verify(reviewRepository, times(1))
+                .findReviewByReviewIdentifier_ReviewId(reviewId);
+        verify(reviewRepository, times(1)).delete(reviewToDelete);
+    }
+
+    @Test
+    void deleteReviewByReviewId_reviewNotFound() {
+        // Arrange
+        String reviewId = "nonExistentReviewId";
+        when(reviewRepository.findReviewByReviewIdentifier_ReviewId(reviewId))
+                .thenReturn(null);
+
+        // Act
+        reviewService.deleteReviewByReviewId(reviewId);
+
+        // Assert
+        verify(reviewRepository, times(1))
+                .findReviewByReviewIdentifier_ReviewId(reviewId);
+        verify(reviewRepository, never()).delete(any());
+    }
+
 }

--- a/ateliermecanique-ws/src/test/java/com/champlain/ateliermecaniquews/zelenium/FrontEndTesting.java
+++ b/ateliermecanique-ws/src/test/java/com/champlain/ateliermecaniquews/zelenium/FrontEndTesting.java
@@ -873,7 +873,38 @@ public class FrontEndTesting {
         $("button[type='submit']").click();
     }
 
+    @Test
+    public void deleteReviewByReviewId() {
 
+        open("https://localhost:3000/");
+        $("a[href='/login']").click();
+        sleep(1000);
+
+        $("input[name='email']").setValue("admin@example.com");
+        $("input[type='password']").setValue("Hello!");
+
+        $("button[type='submit']").click();
+        sleep(1000);
+
+
+        sleep(1000);
+        $("img[src='reviews.svg']").click();
+        sleep(1000);
+
+        String reviewId = "3994efe6-a0d3-48e8-ba53-e80c5b6ad331";
+        SelenideElement reviewLink = $$("td").findBy(text(reviewId));
+        reviewLink.shouldBe(visible).click();
+        sleep(5000);
+
+        $$("button").findBy(text("delete")).click();
+
+        $(".bg-black").shouldBe(visible);
+        $$("button").findBy(text("Yes")).click();
+
+        sleep(1000);
+        switchTo().alert().accept();
+
+        }
 
 }
 


### PR DESCRIPTION
JIRA: link to jira ticket
([link](https://champlainsaintlambert.atlassian.net/browse/ACMS-87))

## Context:
This ticket pertained to implementing the delete reviewByReviewId() method functionality.

## Changes
- deleteReviewByReviewId() method logic
- front-end implementation
- back end testing (positive and negative test cases)
- selenium testing

## Before and After UI (Required for UI-impacting PRs)

After Changes:

![Screenshot 2024-02-14 012915](https://github.com/Iantomasi/ateliermecanique-ws/assets/77695020/a3469746-da86-47b0-a382-fc070b051f2e)

- If Review doesn't belong to user: 
  
![Screenshot 2024-02-14 012755](https://github.com/Iantomasi/ateliermecanique-ws/assets/77695020/6b0352f4-228d-4e94-a240-1795dd2c3747)

- If Admin and/or owner of review deletes the review:
  
![Screenshot 2024-02-14 012851](https://github.com/Iantomasi/ateliermecanique-ws/assets/77695020/820d31fb-3500-44fc-bd2d-d906d9e0c168)

## Dev notes (Optional)
Upped code coverage a bit
![Screenshot 2024-02-14 014514](https://github.com/Iantomasi/ateliermecanique-ws/assets/77695020/51de329c-4bd2-4afa-bcb7-bdf456ad24c0)

